### PR TITLE
ci(workflows): update workflow starters with trusted publishing

### DIFF
--- a/workflow-templates/dotnet-push.yml
+++ b/workflow-templates/dotnet-push.yml
@@ -18,16 +18,29 @@ jobs:
   push:
     environment: publish
     runs-on: windows-2022
+    # Required for Option 2 (nuget.org with Trusted Publishing)
+    permissions:
+      id-token: write
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      # Option 1: Setup for Artifactory (private repos)
       - name: Setup Artifactory
         uses: devolutions/actions/nuget-artifactory-setup@v1
         with:
           artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
           artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+
+      # Option 2: Setup for nuget.org (public repos) using Trusted Publishing (OIDC)
+      # Note: First publish must be done manually by DevOps to configure the trusted publisher
+      # Documentation: https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
+      - name: NuGet login (OIDC)
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_BOT_USERNAME }}
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -43,11 +56,21 @@ jobs:
           output_path: release
           version: ${{ inputs.version }}
 
+      # Option 1: Publish to Artifactory (private repos)
       - name: Push
         if: ${{ inputs.publish }}
         uses: devolutions/actions/dotnet-push@v1
         with:
           working_directory: release
+
+      # Option 2: Publish to nuget.org (public repos)
+      - name: Push
+        if: ${{ inputs.publish }}
+        run: dotnet nuget push release/*.nupkg --api-key $NUGET_API_KEY --source $NUGET_SOURCE --skip-duplicate
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          NUGET_SOURCE: https://api.nuget.org/v3/index.json
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.6

--- a/workflow-templates/npm-push.yml
+++ b/workflow-templates/npm-push.yml
@@ -18,6 +18,10 @@ jobs:
   push:
     environment: publish
     runs-on: ubuntu-22.04
+    # Required for Option 2 (npmjs.com with Trusted Publishing)
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Check out repository
@@ -28,15 +32,16 @@ jobs:
         with:
           node-version: 24.x # depends on the project
 
-      # If push to Artifactory
+      # Option 1: Setup for Artifactory (private repos)
       - name: Setup .npmrc
         uses: devolutions/actions/npmrc-setup@v1
         with:
           npm_token: ${{ secrets.ARTIFACTORY_NPM_TOKEN }}
 
-      # If push to NPMJS
-      - name: Setup .npmrc
-        run: npm set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
+      # Option 2: For npmjs.com (public repos) using Trusted Publishing (OIDC)
+      # No explicit setup step needed - npm uses OIDC automatically when id-token: write is present
+      # Note: First publish must be done manually by DevOps to configure the trusted publisher
+      # Documentation: https://docs.npmjs.com/trusted-publishers
 
       - name: Get npm cache directory
         id: npm-cache-dir
@@ -56,11 +61,16 @@ jobs:
           npm ci
           npm run build
 
-      # this step could vary depending on the project
+      # Option 1: Publish to Artifactory (private repos)
       - name: Push
         if: ${{ github.event.inputs.publish != 'false' }}
         run: |
           npm run publish:jfrog
+
+      # Option 2: Publish to npmjs.com (public repos)
+      - name: Push
+        if: ${{ github.event.inputs.publish != 'false' }}
+        run: npm publish
 
       # this step could vary depending on the project
       - uses: actions/upload-artifact@v4.3.6
@@ -68,8 +78,8 @@ jobs:
           name: package
           path: dist/*
 
-      # If push to NPMJS
+      # Option 2 only: Update Artifactory cache after npmjs.com publish
       - name: Update Artifactory Cache
-        run: gh workflow run update-artifactory-cache.yml --repo Devolutions/scheduled-tasks --field package_name="slauth"
+        run: gh workflow run update-artifactory-cache.yml --repo Devolutions/scheduled-tasks --field package_name="<package-name>"
         env:
           GH_TOKEN: ${{ secrets.DEVOLUTIONSBOT_WRITE_TOKEN }}

--- a/workflow-templates/yarn-push.yml
+++ b/workflow-templates/yarn-push.yml
@@ -13,6 +13,10 @@ jobs:
   push:
     environment: publish
     runs-on: ubuntu-22.04
+    # Required for Option 2 (npmjs.com with Trusted Publishing)
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Check out repository
@@ -23,10 +27,16 @@ jobs:
         with:
           node-version: 24.x # depends on the project
 
+      # Option 1: Setup for Artifactory (private repos)
       - name: Setup .npmrc
         uses: devolutions/actions/npmrc-setup@v1
         with:
           npm_token: ${{ secrets.ARTIFACTORY_NPM_TOKEN }}
+
+      # Option 2: For npmjs.com (public repos) using Trusted Publishing (OIDC)
+      # No explicit setup step needed - npm/yarn uses OIDC automatically when id-token: write is present
+      # Note: First publish must be done manually by DevOps to configure the trusted publisher
+      # Documentation: https://docs.npmjs.com/trusted-publishers
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -55,11 +65,16 @@ jobs:
           npm_token: ${{ secrets.ARTIFACTORY_NPM_TOKEN }}
           repository: npm-local
 
-      # this step could vary depending on the project
+      # Option 1: Publish to Artifactory (private repos)
       - name: Push
         if: ${{ inputs.publish }}
         run: |
           yarn run publish-local
+
+      # Option 2: Publish to npmjs.com (public repos)
+      - name: Push
+        if: ${{ inputs.publish }}
+        run: yarn publish --tag latest
 
       - uses: actions/upload-artifact@v4.3.6
         with:


### PR DESCRIPTION
Update npm-push.yml, yarn-push.yml, and dotnet-push.yml workflow starters to include trusted publishing (OIDC) patterns for npmjs.com and nuget.org.

Changes:
- Add permissions: id-token: write for OIDC authentication
- Add documentation links for trusted publishing setup
- Include commented examples for nuget.org push with NuGet/login@v1
- Note that first publish must be done manually by DevOps

References:
- npmjs: https://docs.npmjs.com/trusted-publishers
- nuget: https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing